### PR TITLE
chore(deps): group Dependabot updates for golangci-lint and CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      golangci-lint:
+        patterns:
+          - "golangci*"
+      ci:
+        patterns:
+          - "*"


### PR DESCRIPTION
Add grouping rules in dependabot.yml to organize weekly update
pull requests. Group golangci-lint related updates separately from
general CI dependencies to improve update management and review
efficiency.