### PR TITLE
docs: add installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 
 The [conf](https://github.com/sv-tools/conf) parser to JSON format.
 
+```shell
+go get github.com/sv-tools/conf-parser-json
+```
 
 ## License
 


### PR DESCRIPTION
Include a shell command to install the conf-parser-json package
using 'go get'. This helps users quickly set up the parser and
improves the clarity of the README documentation.