### PR TITLE
chore: update Go version to 1.24 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sv-tools/conf-parser-json
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0


### PR DESCRIPTION
Simplify Go version specification by removing patch version
from 1.24.0 to 1.24. This aligns with common practice and
ensures compatibility with Go tooling that accepts minor
version only. No functional changes are introduced.