### PR TITLE
fix(parser): add detailed error wrapping in Parser function

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -3,6 +3,7 @@ package confjson
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 )
 
@@ -10,12 +11,12 @@ import (
 func Parser(_ context.Context, r io.Reader) (any, error) {
 	data, err := io.ReadAll(r)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read data: %w", err)
 	}
 
 	var res any
 	if err := json.Unmarshal(data, &res); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse json: %w", err)
 	}
 
 	return res, nil

--- a/parser_test.go
+++ b/parser_test.go
@@ -36,7 +36,7 @@ func TestParserErrors(t *testing.T) {
 
 	data := strings.NewReader(`{"foo": 42, "bar": "test"`)
 	c = conf.New().WithReaders(conf.NewStreamParser(data).WithParser(confjson.Parser))
-	require.EqualError(t, c.Load(t.Context()), "unexpected end of JSON input")
+	require.ErrorContains(t, c.Load(t.Context()), "unexpected end of JSON input")
 }
 
 func ExampleParser() {


### PR DESCRIPTION
Wrap errors returned from io.ReadAll and json.Unmarshal with
contextual messages to improve debugging and error tracing in the
Parser function. This change helps identify the source of failures
more clearly when reading or parsing JSON data.